### PR TITLE
Fix+Refactor: non-standalone builds no longer allowed due to compatibility issues with compiled python modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-util-generic:
 build-all: build-util-os-nt build-util-generic
 
 install:
-	$(PYTHON_FOR_INSTALL_STEP) compile.py --standalone --strip --no-cleanup
+	$(PYTHON_FOR_INSTALL_STEP) compile.py --strip --no-cleanup
 
 clean:
 	rm --preserve-root -Irf */__pycache__/ *.dist/ *.build/ build/ tmp*/ *.egg-info/ .mypy_cache/ .pytest_cache/ */ERROR.log *.exe .coverage compilation-report.xml nuitka-crash-report.xml

--- a/compile.py
+++ b/compile.py
@@ -60,7 +60,7 @@ else:
 
 EXECUTABLE_NAME: str = "viewer" + EXECUTABLE_EXT
 
-parser = CompileArgumentParser(CODE_FOLDER, DEFAULT_INSTALL_PATH)
+parser = CompileArgumentParser(DEFAULT_INSTALL_PATH)
 
 args: CompileNamespace
 nuitka_args: list[str]

--- a/compile_utils/args.py
+++ b/compile_utils/args.py
@@ -70,7 +70,7 @@ class CompileArgumentParser(ArgumentParser):
         NuitkaArgs.WINDOWS_CONSOLE_MODE.value,
     ]
 
-    def __init__(self, code_folder: str, install_path: str) -> None:
+    def __init__(self, install_path: str) -> None:
         super().__init__(
             description="Compiles Personal Image Viewer to an executable",
             epilog=f"Some nuitka arguments are also accepted: {self.VALID_NUITKA_ARGS}",

--- a/compile_utils/args.py
+++ b/compile_utils/args.py
@@ -33,6 +33,11 @@ class NuitkaArgs(StrEnum):
     SHOW_SCONS = "--show-scons"
     SHOW_MEMORY = "--show-memory"
 
+    INCLUDE_DATA_FILES = "--include-data-files"
+    NO_INCLUDE_DATA_FILES = "--noinclude-data-files"
+    INCLUDE_MODULE = "--include-module"
+    NO_INCLUDE_DLLS = "--noinclude-dlls"
+
     def with_value(self, value: str) -> str:
         """Returns the flag in the format {flag}={value}"""
         return f"{self}={value}"

--- a/compile_utils/code_to_skip.py
+++ b/compile_utils/code_to_skip.py
@@ -158,19 +158,6 @@ functions_to_skip: dict[str, set[str]] = {
         "scale_with_quality",
     },
     "PIL._binary": {"i8", "si16be", "si16le", "si32be", "si32le"},
-    "PIL.features": {
-        "check",
-        "check_codec",
-        "check_feature",
-        "get_supported",
-        "get_supported_codecs",
-        "get_supported_features",
-        "get_supported_modules",
-        "pilinfo",
-        "version",
-        "version_codec",
-        "version_feature",
-    },
     "PIL.AvifImagePlugin": {"get_codec_version", "register_mime"},
     "PIL.Image": {
         "__getstate__",
@@ -307,7 +294,6 @@ vars_to_skip: dict[str, set[str]] = {
     "numpy._core.records": {"__all__", "__module__", "numfmt"},
     "numpy._core.shape_base": {"__all__", "array_function_dispatch"},
     "numpy.exceptions": {"__all__", "_is_loaded"},
-    "PIL.features": {"codecs", "features"},
     "PIL.Image": {"MIME", "TYPE_CHECKING"},
     "PIL.ImageDraw": {"Outline", "TYPE_CHECKING"},
     "PIL.ImageFile": {"TYPE_CHECKING"},
@@ -420,14 +406,13 @@ from_imports_to_skip: dict[str, set[str]] = {
         "normalize_axis_tuple",
         "set_module",
     },
-    "PIL.features": {"deprecate"},
     "PIL.Image": {"deprecate"},
     "PIL.ImageMath": {"deprecate"},
     "PIL.ImageMode": {"deprecate"},
     "PIL.JpegImagePlugin": {"deprecate"},
 }
 
-dict_keys_to_skip: dict[str, set[str]] = {"PIL.features": {"tkinter"}}
+dict_keys_to_skip: dict[str, set[str]] = {}
 
 decorators_to_skip: dict[str, set[str]] = {
     f"{IMAGE_VIEWER_NAME}.ui.base": {"abstractmethod"},

--- a/compile_utils/module_dependencies.py
+++ b/compile_utils/module_dependencies.py
@@ -18,9 +18,6 @@ if os.name == "nt":
 # be checked explicitly
 modules_to_include: list[str] = ["numpy._core._exceptions"]
 
-if os.name == "nt":
-    modules_to_include += ["util._os_nt"]
-
 modules_to_skip: list[str] = [
     "argparse",
     "bz2",

--- a/compile_utils/module_dependencies.py
+++ b/compile_utils/module_dependencies.py
@@ -9,12 +9,14 @@ from personal_compile_tools.requirements import Requirement, parse_requirements_
 
 module_dependencies: list[Requirement] = parse_requirements_file("requirements.txt")
 
+compiled_modules: list[str] = ["util._generic"]
+
+if os.name == "nt":
+    compiled_modules += ["util._os_nt"]
+
 # Some modules can't be followed normally or need to
 # be checked explicitly
-modules_to_include: list[str] = [
-    "numpy._core._exceptions",
-    "util._generic",
-]
+modules_to_include: list[str] = ["numpy._core._exceptions"]
 
 if os.name == "nt":
     modules_to_include += ["util._os_nt"]
@@ -175,6 +177,7 @@ modules_to_skip: list[str] = [
     "PIL.ImageTransform",
     "PIL.ImageWin",
     "PIL.TarIO",
+    "PIL.features",
     "PIL.report",
     "py_compile",
     "pydoc",

--- a/compile_utils/module_dependencies.py
+++ b/compile_utils/module_dependencies.py
@@ -9,14 +9,11 @@ from personal_compile_tools.requirements import Requirement, parse_requirements_
 
 module_dependencies: list[Requirement] = parse_requirements_file("requirements.txt")
 
-compiled_modules: list[str] = ["util._generic"]
-
-if os.name == "nt":
-    compiled_modules += ["util._os_nt"]
-
 # Some modules can't be followed normally or need to
 # be checked explicitly
-modules_to_include: list[str] = ["numpy._core._exceptions"]
+modules_to_include: list[str] = ["numpy._core._exceptions", "util._generic"]
+if os.name == "nt":
+    modules_to_include += ["util._os_nt"]
 
 modules_to_skip: list[str] = [
     "argparse",

--- a/compile_utils/nuitka_ext.py
+++ b/compile_utils/nuitka_ext.py
@@ -9,12 +9,7 @@ from compile_utils.module_dependencies import modules_to_include
 
 
 def start_nuitka_compilation(
-    python_path: str,
-    input_file: str,
-    code_dir: str,
-    working_dir: str,
-    nuitka_args: list[str],
-    files_to_include: list[str],
+    python_path: str, input_file: str, working_dir: str, nuitka_args: list[str]
 ) -> Popen:
     """Begins nuitka compilation in another process"""
 
@@ -26,19 +21,13 @@ def start_nuitka_compilation(
     # -mtune=native works as intended
     compile_env["CFLAGS"] = "-O3 -fno-signed-zeros -mtune=native"
 
-    command: list[str] = get_nuitka_command(
-        code_dir, python_path, input_file, nuitka_args, files_to_include
-    )
+    command: list[str] = get_nuitka_command(python_path, input_file, nuitka_args)
 
     return Popen(command, cwd=working_dir, env=compile_env)
 
 
 def get_nuitka_command(
-    code_dir: str,
-    python_path: str,
-    input_file: str,
-    nuitka_args: list[str],
-    files_to_include: list[str],
+    python_path: str, input_file: str, nuitka_args: list[str]
 ) -> list[str]:
     """Returns the command that this package uses to compile"""
     command: list[str] = (
@@ -50,19 +39,18 @@ def get_nuitka_command(
             input_file,
             "--python-flag=-OO,no_annotations,no_warnings,static_hashes",
             "--output-filename=viewer",
+            "--follow-imports",  # TODO: Fix
         ]
         + nuitka_args
         + [
-            f"--include-data-files={os.path.join(code_dir, file)}={file}"
-            for file in files_to_include
+            NuitkaArgs.NO_INCLUDE_DATA_FILES.with_value(glob)
+            for glob in data_files_to_exclude
         ]
-        + [f"--include-module={module}" for module in modules_to_include]
-        + [f"--noinclude-data-files={glob}" for glob in data_files_to_exclude]
-        + [f"--noinclude-dlls={glob}" for glob in dlls_to_exclude]
+        + [
+            NuitkaArgs.INCLUDE_MODULE.with_value(module)
+            for module in modules_to_include
+        ]
+        + [NuitkaArgs.NO_INCLUDE_DLLS.with_value(glob) for glob in dlls_to_exclude]
     )
 
     return command
-
-
-def has_standalone_flag(nuitka_args: list[str]) -> bool:
-    return NuitkaArgs.STANDALONE in nuitka_args

--- a/compile_utils/nuitka_ext.py
+++ b/compile_utils/nuitka_ext.py
@@ -3,10 +3,6 @@
 import os
 from subprocess import Popen
 
-from compile_utils.args import NuitkaArgs
-from compile_utils.code_to_skip import data_files_to_exclude, dlls_to_exclude
-from compile_utils.module_dependencies import modules_to_include
-
 
 def start_nuitka_compilation(
     python_path: str, input_file: str, working_dir: str, nuitka_args: list[str]
@@ -14,7 +10,7 @@ def start_nuitka_compilation(
     """Begins nuitka compilation in another process"""
 
     print("Starting compilation with nuitka")
-    print(f'Using python install "{python_path}"')
+    print("Using python install", python_path)
 
     compile_env = os.environ.copy()
     # -march=native had a race condition that segfaulted on startup
@@ -30,27 +26,14 @@ def get_nuitka_command(
     python_path: str, input_file: str, nuitka_args: list[str]
 ) -> list[str]:
     """Returns the command that this package uses to compile"""
-    command: list[str] = (
-        [
-            python_path,
-            "-OO",
-            "-m",
-            "nuitka",
-            input_file,
-            "--python-flag=-OO,no_annotations,no_warnings,static_hashes",
-            "--output-filename=viewer",
-            "--follow-imports",  # TODO: Fix
-        ]
-        + nuitka_args
-        + [
-            NuitkaArgs.NO_INCLUDE_DATA_FILES.with_value(glob)
-            for glob in data_files_to_exclude
-        ]
-        + [
-            NuitkaArgs.INCLUDE_MODULE.with_value(module)
-            for module in modules_to_include
-        ]
-        + [NuitkaArgs.NO_INCLUDE_DLLS.with_value(glob) for glob in dlls_to_exclude]
-    )
+    command: list[str] = [
+        python_path,
+        "-OO",
+        "-m",
+        "nuitka",
+        input_file,
+        "--python-flag=-OO,no_annotations,no_warnings,static_hashes",
+        "--output-filename=viewer",
+    ] + nuitka_args
 
     return command

--- a/compile_utils/nuitka_ext.py
+++ b/compile_utils/nuitka_ext.py
@@ -3,34 +3,18 @@
 import os
 from subprocess import Popen
 
+from compile_utils.args import NuitkaArgs
 from compile_utils.code_to_skip import data_files_to_exclude, dlls_to_exclude
 from compile_utils.module_dependencies import modules_to_include
-from compile_utils.package_info import MODULES
-
-
-def get_base_cmd_args(python_path: str, input_file: str) -> list[str]:
-    """Returns the base cmd commands that this package uses to compile"""
-    cmd_args: list[str] = (
-        [
-            python_path,
-            "-OO",
-            "-m",
-            "nuitka",
-            input_file,
-            "--python-flag=-OO,no_annotations,no_warnings,static_hashes",
-            "--output-filename=viewer",
-        ]
-        + [f"--include-module={module}" for module in modules_to_include]
-        + [f"--follow-import-to={module}" for module in MODULES]
-        + [f"--noinclude-data-files={glob}" for glob in data_files_to_exclude]
-        + [f"--noinclude-dlls={glob}" for glob in dlls_to_exclude]
-    )
-
-    return cmd_args
 
 
 def start_nuitka_compilation(
-    python_path: str, input_file: str, working_dir: str, extra_nuitka_args: list[str]
+    python_path: str,
+    input_file: str,
+    code_dir: str,
+    working_dir: str,
+    nuitka_args: list[str],
+    files_to_include: list[str],
 ) -> Popen:
     """Begins nuitka compilation in another process"""
 
@@ -42,7 +26,43 @@ def start_nuitka_compilation(
     # -mtune=native works as intended
     compile_env["CFLAGS"] = "-O3 -fno-signed-zeros -mtune=native"
 
-    args: list[str] = get_base_cmd_args(python_path, input_file)
-    args += extra_nuitka_args
+    command: list[str] = get_nuitka_command(
+        code_dir, python_path, input_file, nuitka_args, files_to_include
+    )
 
-    return Popen(args, cwd=working_dir, env=compile_env)
+    return Popen(command, cwd=working_dir, env=compile_env)
+
+
+def get_nuitka_command(
+    code_dir: str,
+    python_path: str,
+    input_file: str,
+    nuitka_args: list[str],
+    files_to_include: list[str],
+) -> list[str]:
+    """Returns the command that this package uses to compile"""
+    command: list[str] = (
+        [
+            python_path,
+            "-OO",
+            "-m",
+            "nuitka",
+            input_file,
+            "--python-flag=-OO,no_annotations,no_warnings,static_hashes",
+            "--output-filename=viewer",
+        ]
+        + nuitka_args
+        + [
+            f"--include-data-files={os.path.join(code_dir, file)}={file}"
+            for file in files_to_include
+        ]
+        + [f"--include-module={module}" for module in modules_to_include]
+        + [f"--noinclude-data-files={glob}" for glob in data_files_to_exclude]
+        + [f"--noinclude-dlls={glob}" for glob in dlls_to_exclude]
+    )
+
+    return command
+
+
+def has_standalone_flag(nuitka_args: list[str]) -> bool:
+    return NuitkaArgs.STANDALONE in nuitka_args

--- a/compile_utils/package_info.py
+++ b/compile_utils/package_info.py
@@ -2,17 +2,3 @@
 
 IMAGE_VIEWER_NAME: str = "image_viewer"
 PROJECT_FILE: str = "pyproject.toml"
-
-# All modules that nuitka will need to follow imports to
-MODULES: list[str] = [
-    "actions",
-    "animation",
-    "config",
-    "constants",
-    "files",
-    "image",
-    "state",
-    "ui",
-    "util",
-    "viewer",
-]

--- a/compile_utils/validation.py
+++ b/compile_utils/validation.py
@@ -29,7 +29,7 @@ def get_required_python_version() -> tuple[int, int]:
     return version_str_to_tuple(project["requires-python"][2:])  # type: ignore
 
 
-def validate_module_requirements(is_standalone: bool) -> None:
+def validate_module_requirements() -> None:
     """Logs warning if installed packages do not match specifications
     in requirements files and raises PackageNotFoundError if they are
     not installed"""
@@ -58,7 +58,7 @@ def validate_module_requirements(is_standalone: bool) -> None:
         except PackageNotFoundError:
             missing_modules.append(requirement.name)
 
-    if is_standalone and len(missing_modules) != 0:
+    if len(missing_modules) != 0:
         raise PackageNotFoundError(
             f"Missing module dependencies {missing_modules}\n"
             "Please install them to compile as standalone"


### PR DESCRIPTION
Annoyed by how nuitka handles this, but they refuse to include compiled python modules. Trying to include them as data files does not work as only the original path they were compiled with seems to work. When moving the .pyd/.so files the import breaks. 